### PR TITLE
ensure mvvm assemblies are loaded

### DIFF
--- a/src/MvvmGen.SourceGenerators.Tests/ViewModelGeneratorTests/Base/ViewModelGeneratorTestBase.cs
+++ b/src/MvvmGen.SourceGenerators.Tests/ViewModelGeneratorTests/Base/ViewModelGeneratorTestBase.cs
@@ -18,7 +18,7 @@ namespace MvvmGen.SourceGenerators
 
         static ViewModelGeneratorTestsBase()
         {
-            #if(MVVMGEN_PURE_CODE_GENERATION)
+            #if(!MVVMGEN_PURE_CODE_GENERATION)
             //Endure MvvmGen is loaded
             System.Reflection.Assembly.Load("MvvmGen");
             #endif

--- a/src/MvvmGen.SourceGenerators.Tests/ViewModelGeneratorTests/Base/ViewModelGeneratorTestBase.cs
+++ b/src/MvvmGen.SourceGenerators.Tests/ViewModelGeneratorTests/Base/ViewModelGeneratorTestBase.cs
@@ -19,8 +19,7 @@ namespace MvvmGen.SourceGenerators
 
         static ViewModelGeneratorTestsBase()
         {
-            //Endure MvvmGen assemblies are loaded
-            Assembly.Load("MvvmGen.SourceGenerators");
+            //Endure MvvmGen is loaded
             Assembly.Load("MvvmGen");
 
             metadataReferences = AppDomain.CurrentDomain.GetAssemblies()

--- a/src/MvvmGen.SourceGenerators.Tests/ViewModelGeneratorTests/Base/ViewModelGeneratorTestBase.cs
+++ b/src/MvvmGen.SourceGenerators.Tests/ViewModelGeneratorTests/Base/ViewModelGeneratorTestBase.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Linq;
+using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -14,9 +15,22 @@ namespace MvvmGen.SourceGenerators
 {
     public class ViewModelGeneratorTestsBase
     {
+        static PortableExecutableReference[] metadataReferences;
+
+        static ViewModelGeneratorTestsBase()
+        {
+            //Endure MvvmGen assemblies are loaded
+            Assembly.Load("MvvmGen.SourceGenerators");
+            Assembly.Load("MvvmGen");
+
+            metadataReferences = AppDomain.CurrentDomain.GetAssemblies()
+                .Where(a => !a.IsDynamic)
+                .Select(a => MetadataReference.CreateFromFile(a.Location))
+                .ToArray();
+        }
+
         protected static void ShouldGenerateExpectedCode(string inputCode, params string[] expectedGeneratedCode)
         {
-            var metadataReferences = AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic).Select(a => MetadataReference.CreateFromFile(a.Location)).ToArray();
             var inputCompilation = CreateCompilation(inputCode, metadataReferences);
 
 #if MVVMGEN_PURE_CODE_GENERATION

--- a/src/MvvmGen.SourceGenerators.Tests/ViewModelGeneratorTests/Base/ViewModelGeneratorTestBase.cs
+++ b/src/MvvmGen.SourceGenerators.Tests/ViewModelGeneratorTests/Base/ViewModelGeneratorTestBase.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Linq;
-using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -19,8 +18,10 @@ namespace MvvmGen.SourceGenerators
 
         static ViewModelGeneratorTestsBase()
         {
+            #if(MVVMGEN_PURE_CODE_GENERATION)
             //Endure MvvmGen is loaded
-            Assembly.Load("MvvmGen");
+            System.Reflection.Assembly.Load("MvvmGen");
+            #endif
 
             metadataReferences = AppDomain.CurrentDomain.GetAssemblies()
                 .Where(a => !a.IsDynamic)


### PR DESCRIPTION
also caches metadataReferences  statically instead of re gen-ing on every test