### PR TITLE
Issue 105 fix2

### DIFF
--- a/src/MvvmGen.SourceGenerators.Tests/MvvmGen.SourceGenerators.Tests.csproj
+++ b/src/MvvmGen.SourceGenerators.Tests/MvvmGen.SourceGenerators.Tests.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <RootNamespace>MvvmGen</RootNamespace>
     <Configurations>Debug;Release;MvvmGen_PureCodeGeneration</Configurations>
+	<LangVersion>13.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MvvmGen.SourceGenerators.Tests/ViewModelGeneratorTests/Base/ViewModelGeneratorTestBase.cs
+++ b/src/MvvmGen.SourceGenerators.Tests/ViewModelGeneratorTests/Base/ViewModelGeneratorTestBase.cs
@@ -64,7 +64,17 @@ namespace MvvmGen.SourceGenerators
                     }
                 }
 
-                Assert.True(found, "Expected code must be in generated sources");
+                var output = $"""
+                    Expected code must be in generated sources
+                    
+                    Generated code:
+                    {generatorResult.GeneratedSources.FirstOrDefault().SourceText.ToString()}
+
+                    Expected code:
+                    {expectedCode}
+                    """;
+
+                Assert.True(found, output);
             }
         }
 

--- a/src/MvvmGen.SourceGenerators.Tests/ViewModelGeneratorTests/PropertyAttributeTests.cs
+++ b/src/MvvmGen.SourceGenerators.Tests/ViewModelGeneratorTests/PropertyAttributeTests.cs
@@ -60,6 +60,8 @@ namespace MyCode
         [InlineData("public")]
         [InlineData("private")]
         [InlineData("protected")]
+        [InlineData("protected internal")]
+        [InlineData("internal")]
         [Theory]
         public void GeneratePartialProperty(string accessModifier)
         {

--- a/src/MvvmGen.SourceGenerators.Tests/ViewModelGeneratorTests/ViewModelGenerateInterfaceAttributeTests.cs
+++ b/src/MvvmGen.SourceGenerators.Tests/ViewModelGeneratorTests/ViewModelGenerateInterfaceAttributeTests.cs
@@ -24,6 +24,8 @@ namespace MyCode
   {{
     [Property] string _firstName;
 
+    [Property] public partial string MiddleName {{ get; set; }}
+
     public string LastName {{ get; set; }}
 
     public string FullName => FirstName + "" "" + LastName;
@@ -58,11 +60,27 @@ namespace MyCode
                 }}
             }}
         }}
+
+        private string _middleName;
+
+        public partial string MiddleName
+        {{
+            get => _middleName;
+            set
+            {{
+                if (_middleName != value)
+                {{
+                    _middleName = value;
+                    OnPropertyChanged(""MiddleName"");
+                }}
+            }}
+        }}
     }}
 
     public interface IEmployeeViewModel : System.ComponentModel.INotifyPropertyChanged
     {{
         string FirstName {{ get; set; }}
+        string MiddleName {{ get; set; }}
         string LastName {{ get; set; }}
         string FullName {{ get; }}
         void CustomMethod();

--- a/src/MvvmGen.SourceGenerators.Tests/ViewModelGeneratorTests/ViewModelGenerateInterfaceAttributeTests.cs
+++ b/src/MvvmGen.SourceGenerators.Tests/ViewModelGeneratorTests/ViewModelGenerateInterfaceAttributeTests.cs
@@ -26,6 +26,8 @@ namespace MyCode
 
     [Property] public partial string MiddleName {{ get; set; }}
 
+    [Property] internal partial string InternalNotForInterface {{ get; set; }}
+
     public string LastName {{ get; set; }}
 
     public string FullName => FirstName + "" "" + LastName;
@@ -72,6 +74,21 @@ namespace MyCode
                 {{
                     _middleName = value;
                     OnPropertyChanged(""MiddleName"");
+                }}
+            }}
+        }}
+
+        private string _internalNotForInterface;
+
+        internal partial string InternalNotForInterface
+        {{
+            get => _internalNotForInterface;
+            set
+            {{
+                if (_internalNotForInterface != value)
+                {{
+                    _internalNotForInterface = value;
+                    OnPropertyChanged(""InternalNotForInterface"");
                 }}
             }}
         }}

--- a/src/MvvmGen.SourceGenerators/Inspectors/ViewModelGenerateInterfaceAttributeInspector.cs
+++ b/src/MvvmGen.SourceGenerators/Inspectors/ViewModelGenerateInterfaceAttributeInspector.cs
@@ -47,9 +47,12 @@ namespace MvvmGen.Inspectors
             {
                 foreach (var propertyToGenerate in propertiesToGenerate)
                 {
-                    properties ??= new();
-                    properties.Add(new InterfaceProperty(propertyToGenerate.PropertyName,
-                        propertyToGenerate.PropertyType, propertyToGenerate.IsReadOnly));
+                    if (propertyToGenerate.AccessModifier == "public") // partial properties can have other access modifiers than public, for example internal
+                    {
+                        properties ??= new();
+                        properties.Add(new InterfaceProperty(propertyToGenerate.PropertyName,
+                            propertyToGenerate.PropertyType, propertyToGenerate.IsReadOnly));
+                    }
                 }
             }
 

--- a/src/MvvmGen.SourceGenerators/Inspectors/ViewModelGenerateInterfaceAttributeInspector.cs
+++ b/src/MvvmGen.SourceGenerators/Inspectors/ViewModelGenerateInterfaceAttributeInspector.cs
@@ -59,6 +59,11 @@ namespace MvvmGen.Inspectors
                 {
                     if (memberSymbol is IPropertySymbol propertySymbol)
                     {
+                        if (propertySymbol.IsPartialDefinition)
+                        {
+                            continue; // Partial properties are already part of propertiesToGenerate list and so added already to the properties list
+                        }
+
                         properties ??= new();
                         properties.Add(new InterfaceProperty(propertySymbol.Name,
                             propertySymbol.Type.ToDisplayString(), propertySymbol.IsReadOnly));

--- a/src/MvvmGen.SourceGenerators/Inspectors/ViewModelMemberInspector.cs
+++ b/src/MvvmGen.SourceGenerators/Inspectors/ViewModelMemberInspector.cs
@@ -216,9 +216,18 @@ namespace MvvmGen.Inspectors
                 }
 
                 var generateBackingField = symbol.Kind == SymbolKind.Property;
+                var accessModifier = "public";
+                if(symbol.Kind== SymbolKind.Property)
+                {
+                    accessModifier = propertySymbol!.DeclaredAccessibility switch
+                    {
+                        Accessibility.ProtectedOrInternal => "protected internal",
+                        _ => propertySymbol!.DeclaredAccessibility.ToString().ToLower()
+                    };
+                }
 
                 propertiesToGenerate.Add(new PropertyToGenerate(propertyName, propertyType, fieldName,
-                    generateBackingField, isReadOnly: false, accessModifier: (symbol.Kind == SymbolKind.Field ? "public" : propertySymbol!.DeclaredAccessibility.ToString().ToLower()))
+                    generateBackingField, isReadOnly: false, accessModifier)
                 {
                     EventsToPublish = eventsToPublish,
                     MethodsToCall = methodsToCall


### PR DESCRIPTION
Ensure access modifiers of partial properties work as excpeted.
Ensure that a public partial property is generated only once in ViewModel interface

Additional fixes for #105 